### PR TITLE
Adjust project title hyphenation rules

### DIFF
--- a/src/pages/Project.js
+++ b/src/pages/Project.js
@@ -50,8 +50,8 @@ const HeaderCard = styled(Card)`
 
 const Title = styled(Header)`
   line-height: 1;
-  hyphens: none;
-  word-break: break-word;
+  hyphens: auto;
+  hyphenate-limit-chars: 12 6 6;
 `;
 
 const MediaContainer = styled.div`

--- a/src/pages/Project.js
+++ b/src/pages/Project.js
@@ -50,7 +50,8 @@ const HeaderCard = styled(Card)`
 
 const Title = styled(Header)`
   line-height: 1;
-  hyphens: auto;
+  hyphens: none;
+  word-break: break-word;
 `;
 
 const MediaContainer = styled.div`
@@ -158,11 +159,12 @@ const formatTitle = (title) => {
   const words = name.split(" ");
 
   // Find the longest word that's suitable for hyphenation
+  // Only hyphenate words that are 12+ characters (like "commemorative")
   let longestWordIndex = -1;
   let longestWordLength = 0;
 
   words.forEach((word, index) => {
-    if (word.length > longestWordLength && word.length >= 8) {
+    if (word.length > longestWordLength && word.length >= 12) {
       longestWordLength = word.length;
       longestWordIndex = index;
     }


### PR DESCRIPTION
Refine project title hyphenation to prevent breaks for shorter words and only apply hyphens to very long words (12+ characters).

---
<a href="https://cursor.com/background-agent?bcId=bc-25717d3a-2876-408f-ba52-d6c9968aea62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25717d3a-2876-408f-ba52-d6c9968aea62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

